### PR TITLE
Bugfix/double quoted imports

### DIFF
--- a/import/dproto/dproto.d
+++ b/import/dproto/dproto.d
@@ -524,16 +524,16 @@ message Person {
 
 unittest
 {
-    import dproto.buffers;
-    import dproto.exception;
-    import dproto.serialize;
-    import dproto.parse;
-    import std.string : strip;
-    auto proto_src = `import "foo.baz.proto";`;
-    auto proto_struct = ParseProtoSchema("<none>", proto_src);
-    auto d_src = proto_struct.toD;
-    assert(`mixin ProtocolBuffer!"foo.baz.proto";` == d_src,
-           "Mixin string should not have two double quotes " ~ d_src);
-    assert(proto_src == proto_struct.toProto.strip,
-           "Round tripping to protobuf source should yield starting text " ~ proto_struct.toProto);
+	import dproto.buffers;
+	import dproto.exception;
+	import dproto.serialize;
+	import dproto.parse;
+	import std.string : strip;
+	auto proto_src = `import "foo/baz.proto";`;
+	auto proto_struct = ParseProtoSchema("<none>", proto_src);
+	auto d_src = proto_struct.toD;
+	assert(`mixin ProtocolBuffer!"foo/baz.proto";` == d_src,
+	       "Mixin string should not have two double quotes " ~ d_src);
+	assert(proto_src == proto_struct.toProto.strip,
+	       "Round tripping to protobuf source should yield starting text " ~ proto_struct.toProto);
 }

--- a/import/dproto/dproto.d
+++ b/import/dproto/dproto.d
@@ -521,3 +521,19 @@ message Person {
 	assert(val.length == 0);
 	assert(p.name == "abc");
 }
+
+unittest
+{
+    import dproto.buffers;
+    import dproto.exception;
+    import dproto.serialize;
+    import dproto.parse;
+    import std.string : strip;
+    auto proto_src = `import "foo.baz.proto";`;
+    auto proto_struct = ParseProtoSchema("<none>", proto_src);
+    auto d_src = proto_struct.toD;
+    assert(`mixin ProtocolBuffer!"foo.baz.proto";` == d_src,
+           "Mixin string should not have two double quotes " ~ d_src);
+    assert(proto_src == proto_struct.toProto.strip,
+           "Round tripping to protobuf source should yield starting text " ~ proto_struct.toProto);
+}

--- a/import/dproto/intermediate.d
+++ b/import/dproto/intermediate.d
@@ -170,7 +170,7 @@ struct ProtoPackage {
 				sink.formattedWrite("package %s; ", packageName);
 			}
 			foreach(dep; dependencies) {
-				sink.formattedWrite("import %s; ");
+                               sink.formattedWrite(`import "%s"; `, dep);
 			}
 		} else {
 			foreach(dep;dependencies) {

--- a/import/dproto/parse.d
+++ b/import/dproto/parse.d
@@ -86,9 +86,7 @@ ProtoPackage ParseProtoSchema(const string name_, string data_) {
 				}
 				case "import": {
 					static if(is(Context==ProtoPackage)) {
-                                               enforce(readChar() == '"', unexpected("imports should be quoted"));
-						context.dependencies ~= readString();
-						enforce(readChar() == '"', unexpected("expected '\"'"));
+						context.dependencies ~= readQuotedPath ();
 						enforce(readChar() == ';', unexpected("expected ';'"));
 						return;
 					} else {
@@ -393,6 +391,14 @@ ProtoPackage ParseProtoSchema(const string name_, string data_) {
 			throw unexpected("unterminated string");
 		}
 
+		string readQuotedPath() {
+			skipWhitespace(true);
+			enforce(readChar() == '"', unexpected("imports should be quoted"));
+			auto ret = readWord(`a-zA-Z0-9_.\-/`);
+			enforce(readChar() == '"', unexpected("imports should be quoted"));
+			return ret;
+		}
+
 		/** Reads a (paren-wrapped), [square-wrapped] or naked symbol name. */
 		string readName() {
 			string optionName;
@@ -412,12 +418,12 @@ ProtoPackage ParseProtoSchema(const string name_, string data_) {
 		}
 
 		/** Reads a non-empty word and returns it. */
-		string readWord() {
+		string readWord(string pattern = `a-zA-Z0-9_.\-`) {
 			skipWhitespace(true);
 			int start = pos;
 			while (pos < data.length) {
 				char c = data[pos];
-				if(c.inPattern(`a-zA-Z0-9_.\-`)) {
+				if(c.inPattern(pattern)) {
 					pos++;
 				} else {
 					break;

--- a/import/dproto/parse.d
+++ b/import/dproto/parse.d
@@ -86,7 +86,9 @@ ProtoPackage ParseProtoSchema(const string name_, string data_) {
 				}
 				case "import": {
 					static if(is(Context==ProtoPackage)) {
+                                               enforce(readChar() == '"', unexpected("imports should be quoted"));
 						context.dependencies ~= readString();
+						enforce(readChar() == '"', unexpected("expected '\"'"));
 						enforce(readChar() == ';', unexpected("expected ';'"));
 						return;
 					} else {


### PR DESCRIPTION
Addresses two problems:

- protobuf imports were being mistranslated in to D code. Specifically

    import "foo.proto"

was rendered as

    ProtocolBuffer!""foo.proto""

- protobuf imports pointing to paths crashed