### PR TITLE
Adds arbitrary size of integers for varint encoding functions

### DIFF
--- a/import/dproto/serialize.d
+++ b/import/dproto/serialize.d
@@ -286,7 +286,7 @@ T fromVarint(R, T = ulong)(R src) @property
 		
 		enforce(
 				offset + 7 <= T.sizeof * 8,
-				"Varint is too big for type " ~ T.stringof
+				"Varint value is too big for the type " ~ T.stringof
 			);
 		
 		offset+=7;

--- a/import/dproto/serialize.d
+++ b/import/dproto/serialize.d
@@ -128,7 +128,7 @@ template MsgType(string T) {
  * Returns: The zigzag-encoded value
  */
 Unsigned!T toZigZag(T)(in T src) pure nothrow @safe @nogc @property
-if(isIntegral!T && isSigned!T)
+	if(isIntegral!T && isSigned!T)
 {
     return cast(Unsigned!T)(
             src >= 0 ?
@@ -154,7 +154,7 @@ unittest {
  * Returns: The raw integer
  */
 Signed!T fromZigZag(T)(inout T src) pure nothrow @safe @nogc @property
-if(isIntegral!T && isUnsigned!T)
+	if(isIntegral!T && isUnsigned!T)
 {
     Signed!T res = (src & 1)
         ?

--- a/import/dproto/serialize.d
+++ b/import/dproto/serialize.d
@@ -130,7 +130,7 @@ template MsgType(string T) {
 Unsigned!T toZigZag(T)(in T src) pure nothrow @safe @nogc @property
 if(isIntegral!T && isSigned!T)
 {
-    return cast( Unsigned!T )(
+    return cast(Unsigned!T)(
             src >= 0 ?
 				src * 2 :
 				-src * 2 - 1

--- a/import/dproto/serialize.d
+++ b/import/dproto/serialize.d
@@ -147,7 +147,7 @@ unittest {
  *  	src = The zigzag-encoded value to decode
  * Returns: The raw integer
  */
-Signed!T fromZigZag(T)(inout T src) pure nothrow @safe @property
+Signed!T fromZigZag(T)(inout T src) pure nothrow @safe @nogc @property
 if(isUnsigned!T)
 {
     Signed!T res = (src & 1)

--- a/import/dproto/serialize.d
+++ b/import/dproto/serialize.d
@@ -128,7 +128,7 @@ template MsgType(string T) {
  * Returns: The zigzag-encoded value
  */
 Unsigned!T toZigZag(T)(in T src) pure nothrow @safe @nogc @property
-if(isSigned!T)
+if(isIntegral!T && isSigned!T)
 {
     return cast( Unsigned!T )(
             src >= 0 ?
@@ -154,7 +154,7 @@ unittest {
  * Returns: The raw integer
  */
 Signed!T fromZigZag(T)(inout T src) pure nothrow @safe @nogc @property
-if(isUnsigned!T)
+if(isIntegral!T && isUnsigned!T)
 {
     Signed!T res = (src & 1)
         ?

--- a/import/dproto/serialize.d
+++ b/import/dproto/serialize.d
@@ -272,9 +272,9 @@ unittest {
  *  	src = The data stream
  * Returns: The decoded value
  */
-T fromVarint(R, T = long)(R src) @property
+T fromVarint(R, T = ulong)(R src) @property
 	if(isInputRange!R && is(ElementType!R : const ubyte) &&
-		isIntegral!T) // FIXME: add && isUnsigned!T)
+		isIntegral!T && isUnsigned!T)
 {
 	immutable ubyte mask = 0b_0111_1111;
 	T ret;

--- a/import/dproto/serialize.d
+++ b/import/dproto/serialize.d
@@ -130,11 +130,11 @@ template MsgType(string T) {
 Unsigned!T toZigZag(T)(in T src) pure nothrow @safe @nogc @property
 	if(isIntegral!T && isSigned!T)
 {
-    return cast(Unsigned!T)(
-            src >= 0 ?
+	return cast(Unsigned!T)(
+			src >= 0 ?
 				src * 2 :
 				-src * 2 - 1
-        );
+		);
 }
 
 unittest {
@@ -156,13 +156,13 @@ unittest {
 Signed!T fromZigZag(T)(inout T src) pure nothrow @safe @nogc @property
 	if(isIntegral!T && isUnsigned!T)
 {
-    Signed!T res = (src & 1)
-        ?
-            -(src >> 1) - 1
-        :
-            src >> 1;
+	Signed!T res = (src & 1)
+		?
+			-(src >> 1) - 1
+		:
+			src >> 1;
 	
-    return res;
+	return res;
 }
 
 unittest {
@@ -238,15 +238,15 @@ long readVarint(R)(ref R src)
 void toVarint(R, T)(ref R r, T src) @trusted @property
 	if(isOutputRange!(R, ubyte)) // FIXME: && isIntegral!T && isUnsigned!T)
 {
-    immutable ubyte maxMask = 0b_1000_0000;
-    
-    while( src >= maxMask )
-    {
-        r.put(cast( ubyte )( src | maxMask ));
-        src >>= 7;
-    }
-    
-    r.put(cast(ubyte) src);
+	immutable ubyte maxMask = 0b_1000_0000;
+	
+	while( src >= maxMask )
+	{
+		r.put(cast( ubyte )( src | maxMask ));
+		src >>= 7;
+	}
+	
+	r.put(cast(ubyte) src);
 }
 
 unittest {

--- a/import/dproto/serialize.d
+++ b/import/dproto/serialize.d
@@ -153,7 +153,7 @@ unittest {
  *  	src = The zigzag-encoded value to decode
  * Returns: The raw integer
  */
-Signed!T fromZigZag(T)(inout T src) pure nothrow @safe @nogc @property
+Signed!T fromZigZag(T)(in T src) pure nothrow @safe @nogc @property
 	if(isIntegral!T && isUnsigned!T)
 {
 	Signed!T res = (src & 1)

--- a/import/dproto/serialize.d
+++ b/import/dproto/serialize.d
@@ -19,6 +19,7 @@ import std.conv;
 import std.exception;
 import std.range;
 import std.system : Endian;
+import std.traits;
 
 /*******************************************************************************
  * Returns whether the given string is a protocol buffer primitive
@@ -146,17 +147,25 @@ unittest {
  *  	src = The zigzag-encoded value to decode
  * Returns: The raw integer
  */
-@nogc long fromZigZag(ulong src) @safe @property pure nothrow {
-	return (cast(long)(src >> 1)) ^ (cast(long)(-(src & 1)));
+Signed!T fromZigZag(T)(inout T src) pure nothrow @safe @property
+if(isUnsigned!T)
+{
+    Signed!T res = (src & 1)
+        ?
+            -(src >> 1) - 1
+        :
+            src >> 1;
+	
+    return res;
 }
 
 unittest {
-	assert(0.fromZigZag() == 0);
-	assert(1.fromZigZag() == -1);
-	assert(2.fromZigZag() == 1);
-	assert(3.fromZigZag() == -2);
-	assert(4294967294.fromZigZag() == 2147483647);
-	assert(4294967295.fromZigZag() == -2147483648);
+	assert(0U.fromZigZag() == 0);
+	assert(1U.fromZigZag() == -1);
+	assert(2U.fromZigZag() == 1);
+	assert(3U.fromZigZag() == -2);
+	assert(4294967294U.fromZigZag() == 2147483647);
+	assert(4294967295U.fromZigZag() == -2147483648);
 }
 
 /*******************************************************************************

--- a/import/dproto/serialize.d
+++ b/import/dproto/serialize.d
@@ -235,14 +235,18 @@ long readVarint(R)(ref R src)
  *  	src = The value to encode
  * Returns: The created VarInt
  */
-void toVarint(R)(ref R r, ulong src) @property
-	if(isOutputRange!(R, ubyte))
+void toVarint(R, T)(ref R r, T src) @trusted @property
+	if(isOutputRange!(R, ubyte)) // FIXME: && isIntegral!T && isUnsigned!T)
 {
-	while(src > 0x7F) {
-		r.put(cast(ubyte)(0x80 | src&0x7F));
-		src >>= 7;
-	}
-	r.put(cast(ubyte)(src&0x7F));
+    immutable ubyte maxMask = 0b_1000_0000;
+    
+    while( src >= maxMask )
+    {
+        r.put(cast( ubyte )( src | maxMask ));
+        src >>= 7;
+    }
+    
+    r.put(cast(ubyte) src);
 }
 
 unittest {

--- a/import/dproto/serialize.d
+++ b/import/dproto/serialize.d
@@ -127,8 +127,14 @@ template MsgType(string T) {
  *  	src = The raw integer to encode
  * Returns: The zigzag-encoded value
  */
-@nogc ulong toZigZag(long src) @safe @property pure nothrow {
-	return (src << 1) ^ (src >> 63);
+Unsigned!T toZigZag(T)(in T src) pure nothrow @safe @nogc @property
+if(isSigned!T)
+{
+    return cast( Unsigned!T )(
+            src >= 0 ?
+				src * 2 :
+				-src * 2 - 1
+        );
 }
 
 unittest {


### PR DESCRIPTION
(I think it is useful for the future changes)

Also:
* line 287: buffer length check to fit into resulting integer value
* line 239: toVarint() shold accept only unsigned integers (old argument is "ulong src"), but it is need to change some other code (buffers.d) - thus, marked as FIXME