### PR TITLE
Some compatibility adjustments

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -19,6 +19,6 @@
 	],
 	"dependencies": {
 		"painlessjson": {"version": "~>1.3.1", "optional": true},
-		"painlesstraits": {"version": "~>0.0.2"}
+		"painlesstraits": {"version": "~>0.0.3"}
 	}
 }

--- a/dub.json
+++ b/dub.json
@@ -19,6 +19,6 @@
 	],
 	"dependencies": {
 		"painlessjson": {"version": "~>1.3.1", "optional": true},
-		"painlesstraits": "~>0.0.1"
+		"painlesstraits": {"version": "~>0.0.2"}
 	}
 }

--- a/import/dproto/attributes.d
+++ b/import/dproto/attributes.d
@@ -106,12 +106,11 @@ template ProtoAccessors()
 
 template ProtoFields(alias self)
 {
-	import std.traits : hasUDA;
-	import std.typetuple : Filter, AliasSeq;
+	import std.typetuple : Filter, TypeTuple;
 
 	alias Field(alias F) = Identity!(__traits(getMember, self, F));
 	alias HasProtoField(alias F) = hasValueAnnotation!(Field!F, ProtoField);
-	alias ProtoFields = Filter!(HasProtoField, AliasSeq!(__traits(allMembers, typeof(self))));
+	alias ProtoFields = Filter!(HasProtoField, TypeTuple!(__traits(allMembers, typeof(self))));
 }
 
 template protoDefault(T) {

--- a/import/dproto/attributes.d
+++ b/import/dproto/attributes.d
@@ -106,12 +106,12 @@ template ProtoAccessors()
 
 template ProtoFields(alias self)
 {
-    import std.traits : hasUDA;
-    import std.typetuple : Filter, TypeTuple;
+	import std.traits : hasUDA;
+	import std.typetuple : Filter, AliasSeq;
 
-    alias Field(alias F) = Identity!(__traits(getMember, self, F));
-    alias HasProtoField(alias F) = hasValueAnnotation!(Field!F, ProtoField);
-    alias ProtoFields = Filter!(HasProtoField, TypeTuple!(__traits(allMembers, typeof(self))));
+	alias Field(alias F) = Identity!(__traits(getMember, self, F));
+	alias HasProtoField(alias F) = hasValueAnnotation!(Field!F, ProtoField);
+	alias ProtoFields = Filter!(HasProtoField, AliasSeq!(__traits(allMembers, typeof(self))));
 }
 
 template protoDefault(T) {
@@ -130,23 +130,23 @@ template protoDefault(T) {
 void serializeField(alias field, R)(ref R r) const
     if (isProtoOutputRange!R)
 {
-    alias fieldType = typeof(field);
-    enum fieldData = getAnnotation!(field, ProtoField);
-    // Serialize if required or if the value isn't the (proto) default
-    bool needsToSerialize = hasValueAnnotation!(field, Required) ||
-                            (field != protoDefault!fieldType);
-    // If we still don't need to serialize, we're done here
-    if (!needsToSerialize)
-    {
-        return;
-    }
-    enum isPacked = hasValueAnnotation!(field, Packed);
-    enum isPackType = is(fieldType == enum) || fieldData.wireType.isBuiltinType;
-    static if (isPacked && isArray!fieldType && isPackType)
-        alias serializer = serializePackedProto;
-    else
-        alias serializer = serializeProto;
-    serializer!fieldData(field, r);
+	alias fieldType = typeof(field);
+	enum fieldData = getAnnotation!(field, ProtoField);
+	// Serialize if required or if the value isn't the (proto) default
+	bool needsToSerialize = hasValueAnnotation!(field, Required) ||
+	                        (field != protoDefault!fieldType);
+	// If we still don't need to serialize, we're done here
+	if (!needsToSerialize)
+	{
+		return;
+	}
+	enum isPacked = hasValueAnnotation!(field, Packed);
+	enum isPackType = is(fieldType == enum) || fieldData.wireType.isBuiltinType;
+	static if (isPacked && isArray!fieldType && isPackType)
+		alias serializer = serializePackedProto;
+	else
+		alias serializer = serializeProto;
+	serializer!fieldData(field, r);
 }
 
 void putProtoVal(string wireType, T, R)(ref T t, auto ref R r)

--- a/import/dproto/attributes.d
+++ b/import/dproto/attributes.d
@@ -11,6 +11,8 @@ import dproto.serialize;
 import painlesstraits : getAnnotation, hasValueAnnotation;
 import dproto.compat;
 
+import std.traits : Identity;
+
 struct ProtoField
 {
 	string wireType;
@@ -27,8 +29,6 @@ struct ProtoField
 
 struct Required {}
 struct Packed {}
-
-alias Id(alias T) = T;
 
 template TagId(alias T)
 	if(hasValueAnnotation!(T, ProtoField))
@@ -67,7 +67,7 @@ template ProtoAccessors()
 		import dproto.attributes;
 		import std.traits;
 		foreach(__member; ProtoFields!this) {
-			alias __field = Id!(__traits(getMember, this, __member));
+			alias __field = Identity!(__traits(getMember, this, __member));
 			serializeField!__field(__r);
 		}
 	}
@@ -81,7 +81,7 @@ template ProtoAccessors()
 			auto __msgdata = __r.readVarint();
 			bool __matched = false;
 			foreach(__member; ProtoFields!this) {
-				alias __field = Id!(__traits(getMember, this, __member));
+				alias __field = Identity!(__traits(getMember, this, __member));
 				alias __fieldData = getAnnotation!(__field, ProtoField);
 				if(__msgdata.msgNum == __fieldData.fieldNumber) {
 					enum wt = __fieldData.wireType;

--- a/import/dproto/compat.d
+++ b/import/dproto/compat.d
@@ -11,7 +11,11 @@ module dproto.compat;
 static if (__VERSION__ < 2066) enum nogc;
 
 static if (__VERSION__ < 2068) {
-	import std.traits : staticMap, isNested;
+	// Code from std.traits
+	// Distributed under the Boost Software License
+	// See http://www.boost.org/LICENSE_1_0.txt
+	import std.typetuple : staticMap;
+	import std.traits : isNested;
 	//Required for FieldNameTuple
 	private enum NameOf(alias T) = T.stringof;
 

--- a/import/dproto/compat.d
+++ b/import/dproto/compat.d
@@ -9,3 +9,5 @@ module dproto.compat;
 
 // nogc compat shim using UDAs (@nogc must appear as function prefix)
 static if (__VERSION__ < 2066) enum nogc;
+
+enum DPROTO_PROTOBUF_VERSION = 2.2;

--- a/import/dproto/compat.d
+++ b/import/dproto/compat.d
@@ -9,30 +9,3 @@ module dproto.compat;
 
 // nogc compat shim using UDAs (@nogc must appear as function prefix)
 static if (__VERSION__ < 2066) enum nogc;
-
-static if (__VERSION__ < 2068) {
-	// Code from std.traits
-	// Distributed under the Boost Software License
-	// See http://www.boost.org/LICENSE_1_0.txt
-	import std.typetuple : staticMap;
-	import std.traits : isNested;
-	//Required for FieldNameTuple
-	private enum NameOf(alias T) = T.stringof;
-
-	/**
-	 * Get as an expression tuple the names of the fields of a struct, class, or
-	 * union. This consists of the fields that take up memory space, excluding the
-	 * hidden fields like the virtual function table pointer or a context pointer
-	 * for nested types. If $(D T) isn't a struct, class, or union returns an
-	 * expression tuple with an empty string.
-	 */
-	template FieldNameTuple(T)
-	{
-		static if (is(T == struct) || is(T == union))
-			alias FieldNameTuple = staticMap!(NameOf, T.tupleof[0 .. $ - isNested!T]);
-		else static if (is(T == class))
-			alias FieldNameTuple = staticMap!(NameOf, T.tupleof);
-		else
-			alias FieldNameTuple = TypeTuple!"";
-	}
-}


### PR DESCRIPTION
- Use the `Identity` template built in to `std.traits`
- Use `__traits(allMembers)` vs `FieldNameTuple` (backwards compatible)