### PR TITLE
Nullable optional message types with default values

### DIFF
--- a/import/dproto/intermediate.d
+++ b/import/dproto/intermediate.d
@@ -204,18 +204,22 @@ struct Field {
 		sink.formattedWrite(`("%s", %s)`, type, id);
 		sink(")\n");
 
-		if(requirement == Requirement.OPTIONAL) {
-			sink(`std.typecons.Nullable!(`);
+		bool wrap_with_nullable =
+			requirement == Requirement.OPTIONAL &&
+			! type.isBuiltinType();
+
+		if(wrap_with_nullable) {
+			sink(`dproto.serialize.PossiblyNullable!(`);
 		}
 		if(type.isBuiltinType) {
 			sink.formattedWrite(`BuffType!"%s"`, type);
 		} else {
 			sink(type);
 		}
-		if(requirement == Requirement.OPTIONAL) {
+		if(wrap_with_nullable) {
 			sink(`)`);
 		}
-		else if(requirement == Requirement.REPEATED) {
+		if(requirement == Requirement.REPEATED) {
 			sink("[]");
 		}
 		sink.formattedWrite(" %s;\n\n", name);

--- a/import/dproto/intermediate.d
+++ b/import/dproto/intermediate.d
@@ -167,7 +167,7 @@ struct Field {
 	uint id;
 	Options options;
 
-	@property const bool hasDefaultValue() {
+	const bool hasDefaultValue() {
 		return null != ("default" in options);
 	}
 	const string defaultValue() {

--- a/import/dproto/serialize.d
+++ b/import/dproto/serialize.d
@@ -52,10 +52,15 @@ template PossiblyNullable(T) {
 template UnspecifiedDefaultValue(T) {
 	static if(is(T == enum)) {
 		import std.traits : EnumMembers;
-		enum DefaultValue = EnumMembers!(T)[0];
+		enum UnspecifiedDefaultValue = EnumMembers!(T)[0];
 	} else {
-		enum DefaultValue = T.init;
+		enum UnspecifiedDefaultValue = T.init;
 	}
+}
+
+template SpecifiedDefaultValue(T, string value) {
+	import std.conv : to;
+	enum SpecifiedDefaultValue = to!T(value);
 }
 
 /*******************************************************************************

--- a/import/dproto/serialize.d
+++ b/import/dproto/serialize.d
@@ -40,6 +40,24 @@ unittest {
 	assert(isBuiltinType("quad") == false);
 }
 
+template PossiblyNullable(T) {
+	static if(is(T == enum)) {
+		alias PossiblyNullable = T;
+	} else {
+		import std.typecons : Nullable;
+		alias PossiblyNullable = Nullable!T;
+	}
+}
+
+template UnspecifiedDefaultValue(T) {
+	static if(is(T == enum)) {
+		import std.traits : EnumMembers;
+		enum DefaultValue = EnumMembers!(T)[0];
+	} else {
+		enum DefaultValue = T.init;
+	}
+}
+
 /*******************************************************************************
  * Maps the given type string to the data type it represents
  */

--- a/import/dproto/unittests.d
+++ b/import/dproto/unittests.d
@@ -676,3 +676,37 @@ unittest
     assert(acct_rx.main.stats.agility == agility, format("Expected %d, got %d", agility, acct_rx.main.stats.agility));
 
 }
+
+unittest
+{
+	mixin ProtocolBufferFromString!q{
+		enum Enum {
+			A = 0;
+			B = 1;
+			C = 2;
+		}
+
+		message Msg {
+			optional Enum unset = 1;
+			optional Enum isset_first = 2 [default = A];
+			optional Enum isset_last = 3 [default = C];
+			required Enum unset_required = 4;
+			required Enum isset_required = 5 [default = B];
+			optional int32 i1 = 6 [default = 42];
+			optional int32 i2 = 7;
+			required int32 i3 = 8 [default = 24];
+			required int32 i4 = 9;
+		}
+	};
+
+	Msg msg;
+	assert(msg.unset == Enum.A);
+	assert(msg.isset_first == Enum.A);
+	assert(msg.isset_last == Enum.C);
+	assert(msg.unset_required == Enum.A);
+	assert(msg.isset_required == Enum.B);
+	assert(msg.i1 == 42);
+	assert(msg.i2 == typeof(msg.i2).init);
+	assert(msg.i3 == 24);
+	assert(msg.i4 == typeof(msg.i4).init);
+}

--- a/import/dproto/unittests.d
+++ b/import/dproto/unittests.d
@@ -667,10 +667,12 @@ unittest
     auto acct = Account();
     auto main = Character();
     main.name = "Hogan";
+    main.stats = Stats();
     main.stats.agility = agility;
     acct.main = main;
     auto ser = acct.serialize();
     Account acct_rx;
     acct_rx.deserialize(ser);
     assert(acct_rx.main.stats.agility == agility, format("Expected %d, got %d", agility, acct_rx.main.stats.agility));
+
 }


### PR DESCRIPTION
Optional message types wrapped in Nullable!T. Default values are put in place where appropriate. The default value for enum types is the first value listed is used as the default value.