### PR TITLE
No replacement for exists()

### DIFF
--- a/import/dproto/serialize.d
+++ b/import/dproto/serialize.d
@@ -49,6 +49,35 @@ template PossiblyNullable(T) {
 	}
 }
 
+
+struct OptionalField(T, T default_val = T.init) {
+	private bool is_set = false;
+	public T value = default_val;
+
+	alias value this;
+
+	auto opGet ( ) {
+		return value;
+	}
+
+	auto opAssign ( T val ) {
+		this.is_set = true;
+		this.value = val;
+
+		return this;
+	}
+
+	bool exists ( ) const {
+		return this.is_set;
+	}
+
+	void unset ( ) {
+		this.value = default_val;
+		this.is_set = false;
+	}
+}
+
+
 template UnspecifiedDefaultValue(T) {
 	static if(is(T == enum)) {
 		import std.traits : EnumMembers;


### PR DESCRIPTION
I just updated to version 2 and it seems that there is no replacement for the `exists()` method.
Before I could check whether an optional field was set with it. 

I did read about Nullable, however, it seems that that is only used for complex types.

```
		bool wrap_with_nullable =
			requirement == Requirement.OPTIONAL &&
			! type.isBuiltinType();
```

In short, there is now no way at all anymore to check if a given field was set or not.