### PR TITLE
Add missing isArray symbol import to dproto.attributes

### DIFF
--- a/import/dproto/attributes.d
+++ b/import/dproto/attributes.d
@@ -11,7 +11,7 @@ import dproto.serialize;
 import painlesstraits : getAnnotation, hasValueAnnotation;
 import dproto.compat;
 
-import std.traits : Identity;
+import std.traits : isArray, Identity;
 import std.typecons : Nullable;
 
 struct ProtoField


### PR DESCRIPTION
`isArray` is used in `dproto.attributes` without having been imported from `std.traits`.  For whatever reason this does not trigger any problems when `dub test` is used, but it certainly shows up when trying to build a dub project using dproto as a dependency!