### PR TITLE
Possible to use dproto in @safe code.

### DIFF
--- a/import/dproto/attributes.d
+++ b/import/dproto/attributes.d
@@ -14,6 +14,8 @@ import dproto.compat;
 import std.traits : isArray, Identity;
 import std.typecons : Nullable;
 
+@safe:
+
 struct ProtoField
 {
 	string wireType;
@@ -39,6 +41,8 @@ template TagId(alias T)
 
 template ProtoAccessors()
 {
+
+@safe:
 
 	static auto fromProto(R)(auto ref R data)
 		if(isProtoInputRange!R)

--- a/import/dproto/serialize.d
+++ b/import/dproto/serialize.d
@@ -19,6 +19,8 @@ import std.range;
 import std.system : Endian;
 import std.traits;
 
+@safe:
+
 /*******************************************************************************
  * Returns whether the given string is a protocol buffer primitive
  *
@@ -254,6 +256,8 @@ long readVarint(R)(ref R src)
  *  	r = output range
  *  	src = The value to encode
  * Returns: The created VarInt
+ * 
+ * Note: This is @trusted for compatibility with @system R.put().
  */
 void toVarint(R, T)(ref R r, T src) @trusted @property
 	if(isOutputRange!(R, ubyte) && isIntegral!T && isUnsigned!T)
@@ -279,6 +283,7 @@ void toVarint(R, T)(ref R r, T src) @trusted @property
  *  	r = output range
  *  	src = The value to encode
  * Returns: The created VarInt
+ * 
  */
 void toVarint(R)(ref R r, long src) @safe @property
 	if(isOutputRange!(R, ubyte))
@@ -312,6 +317,8 @@ unittest {
  * Params:
  *  	src = The data stream
  * Returns: The decoded value
+ * 
+ * Note: This is @trusted for compatibility with @system R.put().
  */
 T fromVarint(T = ulong, R)(R src) @property
 	if(isInputRange!R && is(ElementType!R : const ubyte) &&
@@ -460,7 +467,7 @@ void writeProto(string T, R)(ref R r, BuffType!T src)
 }
 
 /// Ditto
-void writeProto(string T, R)(ref R r, const BuffType!T src)
+void writeProto(string T, R)(ref R r, const BuffType!T src) @trusted
 	if(isProtoOutputRange!R &&
 	  (T.msgType == "double".msgType || T.msgType == "float".msgType))
 {
@@ -468,11 +475,11 @@ void writeProto(string T, R)(ref R r, const BuffType!T src)
 }
 
 /// Ditto
-void writeProto(string T, R)(ref R r, const BuffType!T src)
+void writeProto(string T, R)(ref R r, const BuffType!T src) @trusted
 	if(isProtoOutputRange!R && T.msgType == "string".msgType)
 {
 	toVarint(r, src.length);
-	r.put(cast(ubyte[])src);
+	r.put(cast(const ubyte[]) src);
 }
 
 /*******************************************************************************


### PR DESCRIPTION
1) With this changes it should be possible to use structs generated with dproto in @safe functions. However, parsing protobuf code is still not @safe.

2) Removed deprecated inline imports.
