### PR TITLE
Add support for syntax statement

### DIFF
--- a/import/dproto/intermediate.d
+++ b/import/dproto/intermediate.d
@@ -113,6 +113,7 @@ struct ProtoPackage {
 	}
 	string fileName;
 	string packageName;
+	string syntax;
 	string[] dependencies;
 	EnumType[] enumTypes;
 	MessageType[] messageTypes;

--- a/import/dproto/parse.d
+++ b/import/dproto/parse.d
@@ -76,6 +76,20 @@ ProtoPackage ParseProtoSchema(const string name_, string data_) {
 			string label = readWord();
 
 			switch(label) {
+				case "syntax": {
+					static if(is(Context==ProtoPackage)) {
+						unexpected(context.syntax == null, "too many syntax statements");
+						unexpected(readChar() == '=', "Expected '=' after 'syntax'");
+						unexpected(peekChar() == '"', `Expected opening quote '"' after 'syntax ='`);
+						context.syntax = readQuotedString();
+						unexpected(context.syntax == `"proto2"` || context.syntax == `"proto3"`,
+						           "Unexpected syntax version: `" ~ context.syntax ~ "`");
+						unexpected(readChar() == ';', "Expected ';' after syntax declaration");
+						return;
+					} else {
+						throw new DProtoSyntaxException("syntax in " ~ ContextName);
+					}
+				}
 				case "package": {
 					static if(is(Context==ProtoPackage)) {
 						unexpected(context.packageName == null, "too many package names");

--- a/import/dproto/unittests.d
+++ b/import/dproto/unittests.d
@@ -885,3 +885,51 @@ unittest
 
     assert(t.id == [123]);
 }
+
+unittest
+{
+    // Issue #92
+    import dproto.dproto : ProtocolBufferFromString;
+    import dproto.parse : ParseProtoSchema;
+
+    enum syntaxProto2 = `
+        syntax = "proto2";
+    `;
+	static assert(__traits(compiles, ProtocolBufferFromString!syntaxProto2));
+
+    enum schemaProto2 = ParseProtoSchema("<none>", syntaxProto2);
+    static assert(schemaProto2.syntax == `"proto2"`);
+
+    enum syntaxProto3 = `
+        syntax = "proto3";
+    `;
+	static assert(__traits(compiles, ProtocolBufferFromString!syntaxProto3));
+
+    enum schemaProto3 = ParseProtoSchema("<none>", syntaxProto3);
+    static assert(schemaProto3.syntax == `"proto3"`);
+
+    enum syntaxNoEquals = `
+        syntax "proto2";
+    `;
+	static assert(!__traits(compiles, ProtocolBufferFromString!syntaxNoEquals));
+
+    enum syntaxNoQuotes = `
+        syntax = proto2;
+    `;
+	static assert(!__traits(compiles, ProtocolBufferFromString!syntaxNoQuotes));
+
+    enum syntaxNoLQuote = `
+        syntax = proto2";
+    `;
+	static assert(!__traits(compiles, ProtocolBufferFromString!syntaxNoLQuote));
+
+    enum syntaxNoRQuote = `
+        syntax = "proto2;
+    `;
+	static assert(!__traits(compiles, ProtocolBufferFromString!syntaxNoRQuote));
+
+    enum syntaxNoSemicolon = `
+        syntax = "proto2"
+    `;
+	static assert(!__traits(compiles, ProtocolBufferFromString!syntaxNoSemicolon));
+}


### PR DESCRIPTION
This enables support for the syntax statement described in the proto2 and proto3 spec:
https://developers.google.com/protocol-buffers/docs/reference/proto2-spec#syntax
https://developers.google.com/protocol-buffers/docs/reference/proto3-spec#syntax

`ProtoPackage` has been extended with a new `syntax` field to store the new information now read by `ParseProtoSchema`.

No effort has been made to do anything other than read the statement; future uses of the syntax information have been left for future work.

Fixes msoucy/dproto#92.