### PR TITLE
Option [packed = true] is only allowed on repeated fields.

### DIFF
--- a/import/dproto/parse.d
+++ b/import/dproto/parse.d
@@ -332,6 +332,9 @@ ProtoPackage ParseProtoSchema(const string name_, string data_)
 			}
 			if (c == ';') {
 				pos++;
+				if (labelEnum != Field.Requirement.REPEATED && options.get("packed", "false") != "false") {
+					throw new DProtoSyntaxException("[packed = true] can only be specified for repeated primitive fields");
+				}
 				return Field(labelEnum, type, name, tag, options);
 			}
 			throw new DProtoSyntaxException("Expected ';'");


### PR DESCRIPTION
This PR adds a check for this condition. Otherwise the generated
code contains `Packed` attributes at illegal places.