### PR TITLE
Fix deprecation Identity

### DIFF
--- a/import/dproto/attributes.d
+++ b/import/dproto/attributes.d
@@ -9,8 +9,10 @@ import dproto.serialize;
 import painlesstraits : getAnnotation, hasValueAnnotation;
 import dproto.compat;
 
-import std.traits : isArray, Identity;
+import std.traits : isArray;
 import std.typecons : Nullable;
+
+alias Identity(alias A) = A;
 
 struct ProtoField
 {

--- a/import/dproto/attributes.d
+++ b/import/dproto/attributes.d
@@ -66,7 +66,6 @@ template ProtoAccessors()
 		if(isProtoOutputRange!R)
 	{
 		import dproto.attributes;
-		import std.traits : Identity;
 		foreach(__member; ProtoFields!this) {
 			alias __field = Identity!(__traits(getMember, this, __member));
 			serializeField!__field(__r);
@@ -76,7 +75,6 @@ template ProtoAccessors()
 	void deserialize(R)(auto ref R __r)
 		if(isProtoInputRange!R)
 	{
-		import std.traits : Identity;
 		import dproto.attributes;
 		import painlesstraits : getAnnotation;
 
@@ -99,7 +97,6 @@ template ProtoAccessors()
 
 	void mergeFrom(this This)(auto ref This rhs)
 	{
-		import std.traits : Identity;
 		import dproto.attributes;
 
 		foreach(__member; ProtoFields!this) {


### PR DESCRIPTION
fixes: Deprecation: module `std.traits` member Identity is not visible from module vizserver