### PR TITLE
Fix a package visibility error.

### DIFF
--- a/dprotoc/src/app.d
+++ b/dprotoc/src/app.d
@@ -1,3 +1,5 @@
+module dproto.app;
+
 import std.range;
 import std.algorithm;
 import std.getopt;


### PR DESCRIPTION
This PR fixes `dub run :dprotoc` compile errors. 
```
Performing "debug" build using /home/karita/dlang/dmd-2.090.0/linux/bin64/dmd for x86_64.
painlesstraits 0.3.0: target for configuration "unittest" is up to date.
dproto 2.1.5+commit.3.g0c4b9d3: target for configuration "library" is up to date.
dproto:dprotoc 2.1.5+commit.3.g0c4b9d3: building configuration "application"...
dprotoc/src/app.d(38,18): Error: undefined identifier ProtoPackage
/home/karita/dlang/dmd-2.090.0/linux/bin64/dmd failed with exit code 1.
```
This is because the module `dproto.parse` etc are under the `package` visibility. So I'd like to put the `app.d` under the `dproto` scope.